### PR TITLE
Updated to reflect method signature change in hkdf v1.0.0

### DIFF
--- a/lib/r2d2/util.rb
+++ b/lib/r2d2/util.rb
@@ -100,7 +100,7 @@ module R2D2
       end
 
       def hkdf(key_material, info, length)
-        HKDF.new(key_material, algorithm: 'SHA256', info: info).next_bytes(length)
+        HKDF.new(key_material, algorithm: 'SHA256', info: info).read(length)
       end
     end
   end

--- a/r2d2.gemspec
+++ b/r2d2.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.2"
 
-  s.add_runtime_dependency 'hkdf'
+  s.add_runtime_dependency 'hkdf', "~> 1"
 
   s.add_development_dependency "bundler", "~> 1.15"
   s.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
`hkdf` gem changed the method signature for v1.0.0.

Only noticed due to decryption failing as OpenSSL version did not have KDF support.

Updated method call from `next_bytes` to `read` and added minimum version for `hkdf` gem.